### PR TITLE
FIP - adding a check if the cached version of the javascript is stale

### DIFF
--- a/WebContent/resources/admin.js
+++ b/WebContent/resources/admin.js
@@ -15,6 +15,8 @@
  *
 */
 
+var myVersion = "1.1.7";
+	
 function openDownloadSurveyDialog() {
 	$("#downloadsurvey").dialog("open");
 }
@@ -422,6 +424,8 @@ $(document).ready( function() {
 	      requestStatusChange("resetApproved", getCheckedIds($("#submitted-approved")));
 	});
 	
+	var reloaded = false;	// Prevent accidental infinite reloades when doing the cache management
+	
 	$.ajax({
 	    url: "CertificationServlet",
 	    data: {
@@ -429,8 +433,12 @@ $(document).ready( function() {
 	    },
 	    type: "GET",
 	    dataType : "json",
+	    async: false,
 	    success: function( json ) {
 	    	$("#software-version").text(json);
+	    	if (json != myVersion && !reloaded) {
+	    		location.reload(true);
+	    	}
 	    },
 	    error: function( xhr, status, errorThrown ) {
 	    	handleError( xhr, status, errorThrown);

--- a/src/org/openchain/certification/CertificationServlet.java
+++ b/src/org/openchain/certification/CertificationServlet.java
@@ -70,7 +70,7 @@ public class CertificationServlet extends HttpServlet {
 	/**
 	 * Version of this software - should be updated before every release
 	 */
-	static final String version = "1.1.7";
+	static final String version = "1.1.7";	// Be sure to update the version strings in admin.js
 	
 	static final Logger logger = Logger.getLogger(CertificationServlet.class);
 	


### PR DESCRIPTION
I'm not happy with this current code - I believe the reloadedFlag will get reset to false and we may have an infinite loop if we don't keep the version strings intact.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>