### PR TITLE
Fix caching problems by updating the Tomcat configuration to set caching headers

### DIFF
--- a/WebContent/WEB-INF/web.xml
+++ b/WebContent/WEB-INF/web.xml
@@ -51,4 +51,29 @@
       <param-name>notification_email</param-name>
       <param-value>openchain-conformance@lists.linuxfoundation.org</param-value>
   </context-param>
+  <filter>
+ <filter-name>ExpiresFilter</filter-name>
+ <filter-class>org.apache.catalina.filters.ExpiresFilter</filter-class>
+ <init-param>
+    <param-name>ExpiresByType image</param-name>
+    <param-value>access plus 2 weeks</param-value>
+ </init-param>
+ <init-param>
+    <param-name>ExpiresByType text/css</param-name>
+    <param-value>access plus 6 hours</param-value>
+ </init-param>
+ <init-param>
+    <param-name>ExpiresByType application/javascript</param-name>
+    <param-value>access plus 6 hours</param-value>
+ </init-param>
+ <init-param>
+ <param-name>ExpiresByType text/html</param-name>
+    <param-value>access plus 6 hours</param-value>
+ </init-param>
+</filter>
+<filter-mapping>
+ <filter-name>ExpiresFilter</filter-name>
+ <url-pattern>/*</url-pattern>
+ <dispatcher>REQUEST</dispatcher>
+</filter-mapping>
 </web-app>


### PR DESCRIPTION
Configure the tomcat webserver to cache javasrcipt, html, and css files for only 6 hours

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>