### PR TITLE
Remove the download survey button from the admin screen

### DIFF
--- a/WebContent/admin.html
+++ b/WebContent/admin.html
@@ -58,9 +58,6 @@ Author(s): ViSolve 03/01/2019
 				  <div class="btn-group mr-2" role="group" aria-label="First group">
 				    <!-- <button id="btUpdateSurvey" class="ui-button ui-widget ui-corner-all">Update Survey Questions</button> -->
 				  </div>
-				  <div class="btn-group mr-2" role="group" aria-label="First group">
-				    <button id="btDownloadSurvey" type="button" class="btn btn-success" data-toggle="modal" data-target="#DownloadSurveyModal"><i class="fa fa-download" aria-hidden="true"></i> &nbsp;Download Survey Questions</button>
-				  </div>
 				  <div class="btn-group" role="group" aria-label="second group">
 				    <!-- button id="btUpdateSurvey" type="button" class="btn btn-info" ><i class="fa fa-refresh"></i> &nbsp;Update Survey Questions</button> -->
 				    <button id="btUpdateSurvey" type="button" class="btn btn-info mr-bt15" data-toggle="modal" data-target="#UpdateSurveyModal" ><i class="fa fa-refresh"></i> &nbsp;Update Survey Questions</button>

--- a/WebContent/resources/admin.js
+++ b/WebContent/resources/admin.js
@@ -20,16 +20,6 @@
  */
 var lastUpdateCommit; // Holds the last survey update commit hash
 
-function openDownloadSurveyDialog() {
-	downloadSurvey();
-	//$("#downloadsurvey").dialog("open");
-}
-
-function downloadSurvey() {
-	var specVersion = $("#downloadsurvey-version").val();
-	window.location="CertificationServlet?request=downloadSurvey&specVersion="+specVersion;
-}
-
 /**
  * On initial click of the update survey button, opens a dialog confirming you want to "updateSurveyForReal"
  */
@@ -408,36 +398,6 @@ $(document).ready( function() {
 	});
 	
 	$( "#confirm-update-tabs" ).tabs();
-	
-	$( "#downloadsurvey" ).dialog({
-		title: "Download Survey",
-		autoOpen: false,
-		height: 300,
-		width: 350,
-		modal: true,
-		dialogClass: 'success-dialog',
-		buttons: [{
-			text: "Download",
-			click: function() {
-				$(this).dialog("close");
-				downloadSurvey();
-			}
-		}, {
-			text: "Cancel",
-			click: function() {
-				$(this).dialog("close");
-			}
-		}]
-	}).find("form").on("submit", function(event) {
-		event.preventDefault();
-		$(this).dialog("close");
-		downloadSurvey();
-	});
-	
-	$("#btDownloadSurvey").click(function(event) {
-	      event.preventDefault();
-	      openDownloadSurveyDialog();
-	});
 	
 	$("#btUpdateSurvey").button().button().click(function(event) {
 	      event.preventDefault();


### PR DESCRIPTION
This button is no longer needed with the checkout functionality from git.  It also no longer works.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>