### PR TITLE
Remove unreferenced JavaScript variable

### DIFF
--- a/WebContent/resources/admin.js
+++ b/WebContent/resources/admin.js
@@ -218,7 +218,6 @@ function fillSubmissionStatusTable(submissions) {
 			notSubmittedHtml += html;
 		}
 	}
-	html +='</tbody>';
 	var submittedAwaitingApproval = $("#submitted-awaiting-approval");
 	submittedAwaitingApproval.html(submittedAwaitingApprovalHtml);
 	var submittedApproved = $("#submitted-approved");


### PR DESCRIPTION
This was added on the original responsive UI commit.  The variable does not seem to be used - I believe this line can be safely removed.

@openchain-visolve please review

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>