### PR TITLE
Change the background color for all answers completed from green to orange

### DIFF
--- a/WebContent/styles/newstyle.css
+++ b/WebContent/styles/newstyle.css
@@ -351,7 +351,7 @@ textarea:focus ~ label, input:focus ~ label, textarea:valid ~ label, .select-lab
   
   /* color of accordion header changes when all the questions are answered */
 .all-answered {
-	    background-color: #4CAF50 !important;
+	    background-color: #E25829 !important;
 	    color:white !important;
 }
 /******************************** INDEX CSS *********************************/


### PR DESCRIPTION
This is for the acordian headings when all answers have been completed.  Note: not all answers need to be correct, just completed.

The orange matches the color in the OpenChain logo.

Suggested by @shanecoughlan to avoid confusion with all answers being correct.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>