### PR TITLE
Fix the broken Japenese translation - add escape to double quote

### DIFF
--- a/WebContent/resources/locales/en/translation.json
+++ b/WebContent/resources/locales/en/translation.json
@@ -18,7 +18,7 @@
   "Getting Started_content_2": "Complete the questionnaire.",
   "Getting Started_content_3": "Keep a record of how you met the requirements.",
   "Learn More": "Learn More",
-  "Learn More_content": "You can get more details about OpenChain Self-Certification <a class=\"anchor\" href=\"https://www.openchainproject.org/get-started/conformance" target=\"_blank\">here<\/a>.",
+  "Learn More_content": "You can get more details about OpenChain Self-Certification <a class=\"anchor\" href=\"https://www.openchainproject.org/get-started/conformance\" target=\"_blank\">here<\/a>.",
   "Printable Guide": "Printable Version",
   "offline-conformance-pdf": "You can get the self-certification questionnaire in a printable and sharable format. You can download that <a class=\"anchor\" id=\"dwnquestionnaire\" target=\"_blank\">here</a>",
   

--- a/WebContent/resources/locales/ja/translation.json
+++ b/WebContent/resources/locales/ja/translation.json
@@ -18,7 +18,7 @@
   "Getting Started_content_2": "アンケートに答える。",
   "Getting Started_content_3": "要件をどのように満たしたかを記録する。",
   "Learn More": "さらに詳しく",
-  "Learn More_content": "OpenChainの自己認証に関する詳細は<a class=\"anchor\" href=\"https://www.openchainproject.org/get-started/conformance" target=\"_blank\">こちら<\/a>。",
+  "Learn More_content": "OpenChainの自己認証に関する詳細は<a class=\"anchor\" href=\"https://www.openchainproject.org/get-started/conformance\" target=\"_blank\">こちら<\/a>。",
   "Printable Guide": "印刷版",
   "offline-conformance-pdf": "自己認証アンケートは印刷可能な形式および共有可能な形式でご利用できます。ダウンロードはここから<a href=\"https:\/\/openchain-project.github.io\/conformance-questionnaire\/questionnaire.pdf\"><\/a>可能です。",
   

--- a/src/org/openchain/certification/CertificationServlet.java
+++ b/src/org/openchain/certification/CertificationServlet.java
@@ -77,7 +77,7 @@ public class CertificationServlet extends HttpServlet {
 	/**
 	 * Version of this software - should be updated before every release
 	 */
-	static final String version = "1.2.3"; //$NON-NLS-1$
+	static final String version = "1.2.4"; //$NON-NLS-1$
 	
 	static final Logger logger = Logger.getLogger(CertificationServlet.class);
 	


### PR DESCRIPTION
Signed-off-by: Gary O'Neall <gary@sourceauditor.com>