### PR TITLE
Fix multi-column update error which only shows up in Postgres10+

### DIFF
--- a/src/org/openchain/certification/dbdao/SurveyDbDao.java
+++ b/src/org/openchain/certification/dbdao/SurveyDbDao.java
@@ -753,7 +753,7 @@ public class SurveyDbDao {
 		try {
 			if (updateSectionTitleQuery == null) {
 				updateSectionTitleQuery = this.connection.prepareStatement(
-						"update section set (title) = (?) " + //$NON-NLS-1$
+						"update section set title=? " + //$NON-NLS-1$
 						"where name=? and " + //$NON-NLS-1$
 						"spec_version=(select id from spec where version=? and language=?)"); //$NON-NLS-1$
 			}


### PR DESCRIPTION
Signed-off-by: Gary O'Neall <gary@sourceauditor.com>